### PR TITLE
Migrating to Null Safety

### DIFF
--- a/lib/src/bm25.dart
+++ b/lib/src/bm25.dart
@@ -15,7 +15,7 @@ const bm25FormatString = 'pcnalx';
 /// Converts matchinfo() data to a relevance score (lower is more
 /// relavent).
 double bm25(Uint8List matchinfo,
-    {double k1 = 1.2, double b = 0.75, List<double> weights}) {
+    {double k1 = 1.2, double b = 0.75, List<double>? weights}) {
   final data = Matchinfo.decode(matchinfo);
 
   final termCount = data[_pIndex];
@@ -29,7 +29,7 @@ double bm25(Uint8List matchinfo,
   double score = 0;
 
   for (var c = 0; c < columnCount; c++) {
-    final weight = c < weightsLength ? weights[c] : 1;
+    final weight = c < weightsLength ? weights![c] : 1;
     if (weight == 0) continue;
 
     int avgLength = data[_aIndex + c];

--- a/lib/src/matchinfo.dart
+++ b/lib/src/matchinfo.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 
 class Matchinfo {
-  static Uint32List decode(Uint8List encoded, {Endian endian}) {
+  static Uint32List decode(Uint8List? encoded, {Endian? endian}) {
     if (encoded == null) throw ArgumentError.notNull('encodeded');
     if (endian == null) endian = Endian.host;
 
@@ -21,7 +21,7 @@ class Matchinfo {
     return decoded;
   }
 
-  static Uint8List encode(Uint32List decoded, {Endian endian}) {
+  static Uint8List encode(Uint32List? decoded, {Endian? endian}) {
     if (decoded == null) throw ArgumentError.notNull('decoded');
     if (endian == null) endian = Endian.host;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,12 @@
 name: sqlite_bm25
+repository: http://github.com/silas/dart-sqlite-bm25
+issue_tracker: https://github.com/silas/dart-sqlite-bm25/issues
+description: An Okapi BM25 implementation for the SQLite FTS4 extension.
 version: 0.2.0
 
-description: >-
-  An Okapi BM25 implementation for the SQLite FTS4 extension.
-author: Silas Sewell <silas@sewell.org>
-homepage: http://github.com/silas/dart-sqlite-bm25
-
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  convert: ^2.1.1
-  test: ^1.6.3
+  convert: ^3.1.1
+  test: ^1.22.2

--- a/test/sqlite_bm25_test.dart
+++ b/test/sqlite_bm25_test.dart
@@ -131,7 +131,7 @@ void main() {
       await runTest(IntegrationTest(
         columns: ['word', 'text'],
         documents: sentences.map((v) {
-          final r = List<String>();
+          final r = <String>[];
           r.add(v[0].split(' ')[0]);
           r.add(v[0]);
           return r;
@@ -149,17 +149,17 @@ void main() {
 }
 
 class Result implements Comparable<Result> {
-  int id;
-  double _rank;
+  late int id;
+  late double _rank;
 
   Result(this.id, this._rank);
 
-  Result.fromRow(List<String> row, {List<double> weights}) {
+  Result.fromRow(List<String> row, {List<double>? weights}) {
     if (row.length != 2) {
       throw new TestFailure('Result row should have 2 columns: $row');
     }
     id = int.parse(row[0]);
-    _rank = bm25(hex.decode(row[1]), weights: weights);
+    _rank = bm25(hex.decode(row[1]) as Uint8List, weights: weights);
   }
 
   bool operator ==(dynamic other) {
@@ -189,13 +189,18 @@ class IntegrationTest {
   final List<List<String>> documents;
   final String term;
   final List<Result> expected;
-  final List<double> weights;
+  final List<double>? weights;
 
-  IntegrationTest(
-      {this.columns, this.documents, this.term, this.expected, this.weights});
+  IntegrationTest({
+    required this.columns,
+    required this.documents,
+    required this.term,
+    required this.expected,
+    this.weights,
+  });
 
   Future<void> execute() async {
-    List<String> statements = List();
+    List<String> statements = [];
 
     statements.add(_createTable());
 
@@ -234,7 +239,7 @@ class IntegrationTest {
         .where((v) => v.isNotEmpty)
         .map((v) => Result.fromRow(v.split('|'), weights: weights))
         .toList()
-          ..sort();
+      ..sort();
 
     expected.sort();
 
@@ -246,10 +251,10 @@ class IntegrationTest {
   }
 
   String _insert(int id, List<String> values) {
-    var columnsSql = _strings(List()
+    var columnsSql = _strings([]
       ..add('rowid')
       ..addAll(columns));
-    var valuesSql = _strings(List()
+    var valuesSql = _strings([]
       ..add('$id')
       ..addAll(values));
 


### PR DESCRIPTION
Problem: when migrating my flutter code which depends on this package, running `flutter pub outdated --mode=null-safety` will list this as no null safety support
So I need this package to support the null safety feature, furthermore the new dart 3 alpha will require null-safety.
Overall changes:
- adding the "?" or "!" for several variables, to support null safety
- upgrading the dependencies to the latest version, which already support null safety
- removing deprecated author line, adding repo and issue tracker link
- replacing List constructor to literals

I am not able to invoke `dart test` in WSL2, so i didn't check the test cases